### PR TITLE
At ticket3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,4 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+*launchSettings.json

--- a/Bangazon/Controllers/ProductTypesController.cs
+++ b/Bangazon/Controllers/ProductTypesController.cs
@@ -35,9 +35,7 @@ namespace Bangazon.Controllers
 
             var productType = await _context.ProductType
                 .Include(pt => pt.Products)
-                .FirstOrDefaultAsync(m => m.ProductTypeId == id);
-
-          
+                .FirstOrDefaultAsync(m => m.ProductTypeId == id);         
 
             if (productType == null)
             {

--- a/Bangazon/Controllers/ProductTypesController.cs
+++ b/Bangazon/Controllers/ProductTypesController.cs
@@ -34,7 +34,11 @@ namespace Bangazon.Controllers
             }
 
             var productType = await _context.ProductType
+                .Include(pt => pt.Products)
                 .FirstOrDefaultAsync(m => m.ProductTypeId == id);
+
+          
+
             if (productType == null)
             {
                 return NotFound();

--- a/Bangazon/Models/ProductType.cs
+++ b/Bangazon/Models/ProductType.cs
@@ -17,6 +17,6 @@ namespace Bangazon.Models
     [NotMapped]
     public int Quantity { get; set; }
 
-    public virtual ICollection<Product> Products { get; set; }
-  }
+        public virtual ICollection<Product> Products { get; set; }
+    }
 }

--- a/Bangazon/Views/ProductTypes/Details.cshtml
+++ b/Bangazon/Views/ProductTypes/Details.cshtml
@@ -16,7 +16,7 @@
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.Label)
         </dd>
-        <hr />
+      
             <dd class="col-sm-10">
                 <table class="table">
                     <tr>

--- a/Bangazon/Views/ProductTypes/Details.cshtml
+++ b/Bangazon/Views/ProductTypes/Details.cshtml
@@ -10,12 +10,34 @@
     <h4>ProductType</h4>
     <hr />
     <dl class="row">
-        <dt class = "col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Label)
         </dt>
-        <dd class = "col-sm-10">
+        <dd class="col-sm-10">
             @Html.DisplayFor(model => model.Label)
         </dd>
+        <hr />
+            <dd class="col-sm-10">
+                <table class="table">
+                    <tr>
+                        <th>Products</th>
+                        <th>Title</th>
+                        <th>Quantity</th>
+                        <th>Price</th>
+                    </tr>
+        @foreach (var prod in Model.Products)
+        {
+
+                    <tr>
+                        <td></td>
+                        <td>@prod.Title</td>
+                        <td>@prod.Quantity</td>
+                        <td>@prod.Price</td>
+                    </tr>
+
+        }
+                    </table>
+            </dd>
     </dl>
 </div>
 <div>

--- a/Bangazon/Views/ProductTypes/Details.cshtml
+++ b/Bangazon/Views/ProductTypes/Details.cshtml
@@ -4,23 +4,14 @@
     ViewData["Title"] = "Details";
 }
 
-<h1>Details</h1>
+    <h1> @Html.DisplayFor(model => model.Label)</h1>
 
 <div>
-    <h4>ProductType</h4>
     <hr />
-    <dl class="row">
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Label)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Label)
-        </dd>
-      
+    <dl class="row">   
             <dd class="col-sm-10">
                 <table class="table">
                     <tr>
-                        <th>Products</th>
                         <th>Title</th>
                         <th>Quantity</th>
                         <th>Price</th>
@@ -28,12 +19,13 @@
         @foreach (var prod in Model.Products)
         {
 
-                    <tr>
-                        <td></td>
-                        <td>@prod.Title</td>
-                        <td>@prod.Quantity</td>
-                        <td>@prod.Price</td>
-                    </tr>
+                <tr>
+
+                    <td><a asp-action="Details" asp-controller="Products" asp-route-id="@prod.ProductId">
+                    @prod.Title</a></td>
+                    <td>@prod.Quantity</td>
+                    <td>@prod.Price</td>
+                </tr>
 
         }
                     </table>

--- a/Bangazon/Views/Products/Details.cshtml
+++ b/Bangazon/Views/Products/Details.cshtml
@@ -9,12 +9,12 @@
 <div>
     <h4>Product</h4>
     <hr />
-    <dl class="row">
+    <dl class="row">     
         <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.DateCreated)
+            @Html.DisplayNameFor(model => model.Title)
         </dt>
         <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.DateCreated)
+            @Html.DisplayFor(model => model.Title)
         </dd>
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.Description)
@@ -23,10 +23,10 @@
             @Html.DisplayFor(model => model.Description)
         </dd>
         <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Title)
+            @Html.DisplayNameFor(model => model.Quantity)
         </dt>
         <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Title)
+            @Html.DisplayFor(model => model.Quantity)
         </dd>
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.Price)
@@ -34,43 +34,8 @@
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.Price)
         </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Quantity)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Quantity)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.City)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.City)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.ImagePath)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.ImagePath)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Active)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Active)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.User)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.User.Id)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.ProductType)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.ProductType.Label)
-        </dd>
     </dl>
+    <button class="btn btn-primary">Add to Order</button>
 </div>
 <div>
     <a asp-action="Edit" asp-route-id="@Model.ProductId">Edit</a> |

--- a/Bangazon/Views/Shared/_Layout.cshtml
+++ b/Bangazon/Views/Shared/_Layout.cshtml
@@ -33,13 +33,13 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Product Types</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="ProductTypes" asp-action="Index">Product Types</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Sell Something</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Products" asp-action="Index">Sell Something</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">View Cart</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Orders" asp-action="Index">View Cart</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>


### PR DESCRIPTION
# Description

when you click details for any product type, you will get a list of all products within that type and will display title, price, and quantity on each product. 

later the details button will be replaced with a hyperlink on the product type name


Fixes Issue # (link issue ticket here)

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions
fetch
checkout at-ticket3
go to product type, click detail, see the list of products for that type



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added test instructions that prove my fix is effective or that my feature works
