### PR TITLE
Add payment type, new search bar.

### DIFF
--- a/Bangazon/Areas/Identity/IdentityHostingStartup.cs
+++ b/Bangazon/Areas/Identity/IdentityHostingStartup.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Bangazon.Data;
+using Bangazon.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: HostingStartup(typeof(Bangazon.Areas.Identity.IdentityHostingStartup))]
+namespace Bangazon.Areas.Identity
+{
+    public class IdentityHostingStartup : IHostingStartup
+    {
+        public void Configure(IWebHostBuilder builder)
+        {
+            builder.ConfigureServices((context, services) => {
+            });
+        }
+    }
+}

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/Index.cshtml
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/Index.cshtml
@@ -1,0 +1,46 @@
+﻿@page
+@model IndexModel
+@{
+    ViewData["Title"] = "Profile";
+    ViewData["ActivePage"] = ManageNavPages.Index;
+}
+
+<h4>@ViewData["Title"]</h4>
+<partial name="_StatusMessage" for="StatusMessage" />
+<div class="row">
+    <div class="col-md-6">
+        <form id="profile-form" method="post">
+            <div asp-validation-summary="All" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Username"></label>
+                <input asp-for="Username" class="form-control" disabled />
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.Email"></label>
+                @if (Model.IsEmailConfirmed)
+                {
+                    <div class="input-group">
+                        <input asp-for="Input.Email" class="form-control" />
+                        <span class="input-group-addon" aria-hidden="true"><span class="glyphicon glyphicon-ok text-success"></span></span>
+                    </div>
+                }
+                else
+                {
+                    <input asp-for="Input.Email" class="form-control" />
+                    <button id="email-verification" type="submit" asp-page-handler="SendVerificationEmail" class="btn btn-link">Send verification email</button>
+                }
+                <span asp-validation-for="Input.Email" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.PhoneNumber"></label>
+                <input asp-for="Input.PhoneNumber" class="form-control" />
+                <span asp-validation-for="Input.PhoneNumber" class="text-danger"></span>
+            </div>
+            <button id="update-profile-button" type="submit" class="btn btn-primary">Save</button>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Bangazon.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Bangazon.Areas.Identity.Pages.Account.Manage
+{
+    public partial class IndexModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly IEmailSender _emailSender;
+
+        public IndexModel(
+            UserManager<ApplicationUser> userManager,
+            SignInManager<ApplicationUser> signInManager,
+            IEmailSender emailSender)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _emailSender = emailSender;
+        }
+
+        public string Username { get; set; }
+
+        public bool IsEmailConfirmed { get; set; }
+
+        [TempData]
+        public string StatusMessage { get; set; }
+
+        [BindProperty]
+        public InputModel Input { get; set; }
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            public string Email { get; set; }
+
+            [Phone]
+            [Display(Name = "Phone number")]
+            public string PhoneNumber { get; set; }
+        }
+
+        public async Task<IActionResult> OnGetAsync()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
+            }
+
+            var userName = await _userManager.GetUserNameAsync(user);
+            var email = await _userManager.GetEmailAsync(user);
+            var phoneNumber = await _userManager.GetPhoneNumberAsync(user);
+
+            Username = userName;
+
+            Input = new InputModel
+            {
+                Email = email,
+                PhoneNumber = phoneNumber
+            };
+
+            IsEmailConfirmed = await _userManager.IsEmailConfirmedAsync(user);
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
+            }
+
+            var email = await _userManager.GetEmailAsync(user);
+            if (Input.Email != email)
+            {
+                var setEmailResult = await _userManager.SetEmailAsync(user, Input.Email);
+                if (!setEmailResult.Succeeded)
+                {
+                    var userId = await _userManager.GetUserIdAsync(user);
+                    throw new InvalidOperationException($"Unexpected error occurred setting email for user with ID '{userId}'.");
+                }
+            }
+
+            var phoneNumber = await _userManager.GetPhoneNumberAsync(user);
+            if (Input.PhoneNumber != phoneNumber)
+            {
+                var setPhoneResult = await _userManager.SetPhoneNumberAsync(user, Input.PhoneNumber);
+                if (!setPhoneResult.Succeeded)
+                {
+                    var userId = await _userManager.GetUserIdAsync(user);
+                    throw new InvalidOperationException($"Unexpected error occurred setting phone number for user with ID '{userId}'.");
+                }
+            }
+
+            await _signInManager.RefreshSignInAsync(user);
+            StatusMessage = "Your profile has been updated";
+            return RedirectToPage();
+        }
+
+        public async Task<IActionResult> OnPostSendVerificationEmailAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
+            }
+
+
+            var userId = await _userManager.GetUserIdAsync(user);
+            var email = await _userManager.GetEmailAsync(user);
+            var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+            var callbackUrl = Url.Page(
+                "/Account/ConfirmEmail",
+                pageHandler: null,
+                values: new { userId = userId, code = code },
+                protocol: Request.Scheme);
+            await _emailSender.SendEmailAsync(
+                email,
+                "Confirm your email",
+                $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+
+            StatusMessage = "Verification email sent. Please check your email.";
+            return RedirectToPage();
+        }
+    }
+}

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/ManageNavPages.cs
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/ManageNavPages.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Bangazon.Areas.Identity.Pages.Account.Manage
+{
+    public static class ManageNavPages
+    {
+        public static string Index => "Index";
+
+        public static string ChangePassword => "ChangePassword";
+
+        public static string ExternalLogins => "ExternalLogins";
+
+        public static string PersonalData => "PersonalData";
+
+        public static string TwoFactorAuthentication => "TwoFactorAuthentication";
+        public static string PaymentOptions => "PaymentOptions";
+
+        public static string IndexNavClass(ViewContext viewContext) => PageNavClass(viewContext, Index);
+
+        public static string ChangePasswordNavClass(ViewContext viewContext) => PageNavClass(viewContext, ChangePassword);
+
+        public static string ExternalLoginsNavClass(ViewContext viewContext) => PageNavClass(viewContext, ExternalLogins);
+
+        public static string PersonalDataNavClass(ViewContext viewContext) => PageNavClass(viewContext, PersonalData);
+        public static string PaymentOptionsNavClass(ViewContext viewContext) => PageNavClass(viewContext, PaymentOptions);
+
+        public static string TwoFactorAuthenticationNavClass(ViewContext viewContext) => PageNavClass(viewContext, TwoFactorAuthentication);
+
+        private static string PageNavClass(ViewContext viewContext, string page)
+        {
+            var activePage = viewContext.ViewData["ActivePage"] as string
+                ?? System.IO.Path.GetFileNameWithoutExtension(viewContext.ActionDescriptor.DisplayName);
+            return string.Equals(activePage, page, StringComparison.OrdinalIgnoreCase) ? "active" : null;
+        }
+    }
+}

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml
@@ -1,0 +1,17 @@
+﻿@inject SignInManager<ApplicationUser> SignInManager
+@{
+    var hasExternalLogins = (await SignInManager.GetExternalAuthenticationSchemesAsync()).Any();
+}
+    <ul class="nav nav-pills flex-column">
+        <li class="nav-item"><a class="nav-link @ManageNavPages.IndexNavClass(ViewContext)" id="profile" asp-page="./Index">Profile</a></li>
+        <li class="nav-item"><a class="nav-link @ManageNavPages.ChangePasswordNavClass(ViewContext)" id="change-password" asp-page="./ChangePassword">Password</a></li>
+        @if (hasExternalLogins)
+        {
+            <li id="external-logins" class="nav-item"><a id="external-login" class="nav-link @ManageNavPages.ExternalLoginsNavClass(ViewContext)" asp-page="./ExternalLogins">External logins</a></li>
+        }
+        <li class="nav-item"><a class="nav-link @ManageNavPages.TwoFactorAuthenticationNavClass(ViewContext)" id="two-factor" asp-page="./TwoFactorAuthentication">Two-factor authentication</a></li>
+        <li class="nav-item"><a class="nav-link @ManageNavPages.PersonalDataNavClass(ViewContext)" id="personal-data" asp-page="./PersonalData">Personal data</a></li>
+        <li class="nav-item">
+            <a class="nav-link" asp-area="" asp-controller="PaymentTypes" asp-action="Index">Payment Options</a>
+        </li>
+    </ul>

--- a/Bangazon/Areas/Identity/Pages/Account/Manage/_ViewImports.cshtml
+++ b/Bangazon/Areas/Identity/Pages/Account/Manage/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+﻿@using Bangazon.Areas.Identity.Pages.Account.Manage

--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -7,22 +7,32 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using Bangazon.Data;
 using Bangazon.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Bangazon.Controllers
 {
     public class PaymentTypesController : Controller
     {
         private readonly ApplicationDbContext _context;
+        private readonly UserManager<ApplicationUser> _userManager;
 
-        public PaymentTypesController(ApplicationDbContext context)
+        public PaymentTypesController(ApplicationDbContext context,
+            UserManager<ApplicationUser> userManager)
         {
             _context = context;
+            _userManager = userManager;
         }
 
+        // This method will be called every time we need to get the current user
+        private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
+
         // GET: PaymentTypes
+        [Authorize]
         public async Task<IActionResult> Index()
         {
-            var applicationDbContext = _context.PaymentType.Include(p => p.User);
+            var currentUser = GetCurrentUserAsync();
+            var applicationDbContext = _context.PaymentType.Include(p => p.User).Where(p => p.UserId == currentUser.Result.Id);
             return View(await applicationDbContext.ToListAsync());
         }
 
@@ -46,9 +56,9 @@ namespace Bangazon.Controllers
         }
 
         // GET: PaymentTypes/Create
+        [Authorize]
         public IActionResult Create()
         {
-            ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id");
             return View();
         }
 
@@ -57,15 +67,21 @@ namespace Bangazon.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("PaymentTypeId,DateCreated,Description,AccountNumber,UserId")] PaymentType paymentType)
+        [Authorize]
+        public async Task<IActionResult> Create(PaymentType paymentType)
         {
+            ModelState.Remove("UserId");
+            ModelState.Remove("User");
+
             if (ModelState.IsValid)
             {
+                var currentUser = await GetCurrentUserAsync();
+                paymentType.UserId = currentUser.Id;
                 _context.Add(paymentType);
+
                 await _context.SaveChangesAsync();
                 return RedirectToAction(nameof(Index));
             }
-            ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id", paymentType.UserId);
             return View(paymentType);
         }
 

--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -86,6 +86,7 @@ namespace Bangazon.Controllers
         }
 
         // GET: PaymentTypes/Edit/5
+        [Authorize]
         public async Task<IActionResult> Edit(int? id)
         {
             if (id == null)
@@ -107,6 +108,7 @@ namespace Bangazon.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [Authorize]
         public async Task<IActionResult> Edit(int id, [Bind("PaymentTypeId,DateCreated,Description,AccountNumber,UserId")] PaymentType paymentType)
         {
             if (id != paymentType.PaymentTypeId)
@@ -139,16 +141,23 @@ namespace Bangazon.Controllers
         }
 
         // GET: PaymentTypes/Delete/5
+        [Authorize]
         public async Task<IActionResult> Delete(int? id)
         {
             if (id == null)
             {
                 return NotFound();
             }
+            var currentUser = GetCurrentUserAsync().Result;
 
             var paymentType = await _context.PaymentType
                 .Include(p => p.User)
                 .FirstOrDefaultAsync(m => m.PaymentTypeId == id);
+            if (paymentType.UserId != currentUser.Id)
+            {
+                return RedirectToAction(nameof(Index));
+            }
+
             if (paymentType == null)
             {
                 return NotFound();

--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -85,60 +85,60 @@ namespace Bangazon.Controllers
             return View(paymentType);
         }
 
-        // GET: PaymentTypes/Edit/5
-        [Authorize]
-        public async Task<IActionResult> Edit(int? id)
-        {
-            if (id == null)
-            {
-                return NotFound();
-            }
+        //// GET: PaymentTypes/Edit/5
+        //[Authorize]
+        //public async Task<IActionResult> Edit(int? id)
+        //{
+        //    if (id == null)
+        //    {
+        //        return NotFound();
+        //    }
 
-            var paymentType = await _context.PaymentType.FindAsync(id);
-            if (paymentType == null)
-            {
-                return NotFound();
-            }
-            ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id", paymentType.UserId);
-            return View(paymentType);
-        }
+        //    var paymentType = await _context.PaymentType.FindAsync(id);
+        //    if (paymentType == null)
+        //    {
+        //        return NotFound();
+        //    }
+        //    ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id", paymentType.UserId);
+        //    return View(paymentType);
+        //}
 
-        // POST: PaymentTypes/Edit/5
-        // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
-        // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        [Authorize]
-        public async Task<IActionResult> Edit(int id, [Bind("PaymentTypeId,DateCreated,Description,AccountNumber,UserId")] PaymentType paymentType)
-        {
-            if (id != paymentType.PaymentTypeId)
-            {
-                return NotFound();
-            }
+        //// POST: PaymentTypes/Edit/5
+        //// To protect from overposting attacks, please enable the specific properties you want to bind to, for 
+        //// more details see http://go.microsoft.com/fwlink/?LinkId=317598.
+        //[HttpPost]
+        //[ValidateAntiForgeryToken]
+        //[Authorize]
+        //public async Task<IActionResult> Edit(int id, [Bind("PaymentTypeId,DateCreated,Description,AccountNumber,UserId")] PaymentType paymentType)
+        //{
+        //    if (id != paymentType.PaymentTypeId)
+        //    {
+        //        return NotFound();
+        //    }
 
-            if (ModelState.IsValid)
-            {
-                try
-                {
-                    _context.Update(paymentType);
-                    await _context.SaveChangesAsync();
-                }
-                catch (DbUpdateConcurrencyException)
-                {
-                    if (!PaymentTypeExists(paymentType.PaymentTypeId))
-                    {
-                        return NotFound();
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-                return RedirectToAction(nameof(Index));
-            }
-            ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id", paymentType.UserId);
-            return View(paymentType);
-        }
+        //    if (ModelState.IsValid)
+        //    {
+        //        try
+        //        {
+        //            _context.Update(paymentType);
+        //            await _context.SaveChangesAsync();
+        //        }
+        //        catch (DbUpdateConcurrencyException)
+        //        {
+        //            if (!PaymentTypeExists(paymentType.PaymentTypeId))
+        //            {
+        //                return NotFound();
+        //            }
+        //            else
+        //            {
+        //                throw;
+        //            }
+        //        }
+        //        return RedirectToAction(nameof(Index));
+        //    }
+        //    ViewData["UserId"] = new SelectList(_context.ApplicationUsers, "Id", "Id", paymentType.UserId);
+        //    return View(paymentType);
+        //}
 
         // GET: PaymentTypes/Delete/5
         [Authorize]

--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -30,19 +30,31 @@ namespace Bangazon.Controllers
 
         // The product index view has been changed to show the 20 products needed for the homepage model. 
         // GET: Products
-        public async Task<IActionResult> Index(string searchString)
+        public async Task<IActionResult> Index(string searchString, string SearchBar)
         {
             ViewData["CurrentFilter"] = searchString;
+            ViewData["SearchBar"] = SearchBar;
 
             var applicationDbContext = _context.Product.Include(p => p.ProductType).Include(p => p.User);
             var products = applicationDbContext.OrderBy(p => p.DateCreated).Take(20);
 
             if (!String.IsNullOrEmpty(searchString))
             {
-                products = products.Where(p => p.Title.ToUpper().Contains(searchString.ToUpper())
+                switch (SearchBar)
+                {
+                    case "1":
+                        products = products.Where(p => p.City.ToUpper().Contains(searchString.ToUpper()));
+                        break;
+                    case "2":
+                        products = products.Where(p => p.Title.ToUpper().Contains(searchString.ToUpper()));
+                        break;
+                    default:
+                        products = products.Where(p => p.Title.ToUpper().Contains(searchString.ToUpper())
                                        || p.City.ToUpper().Contains(searchString.ToUpper()));
-            }
+                        break;
+                }
 
+            }
 
             return View(await products.ToListAsync());
         }

--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -29,6 +29,8 @@ namespace Bangazon.Controllers
         private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
 
         // The product index view has been changed to show the 20 products needed for the homepage model. 
+        // The index controller also adds a search bar, with a dropdown filter to allow searches by city,
+        // product name, or both.
         // GET: Products
         public async Task<IActionResult> Index(string searchString, string SearchBar)
         {

--- a/Bangazon/Views/PaymentTypes/Create.cshtml
+++ b/Bangazon/Views/PaymentTypes/Create.cshtml
@@ -23,18 +23,14 @@
                 <span asp-validation-for="AccountNumber" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="UserId" class="control-label"></label>
-                <select asp-for="UserId" class ="form-control" asp-items="ViewBag.UserId"></select>
-            </div>
-            <div class="form-group">
-                <input type="submit" value="Create" class="btn btn-primary" />
+                <input type="submit" value="Add payment to account" class="btn btn-primary" />
             </div>
         </form>
     </div>
 </div>
 
 <div>
-    <a asp-action="Index">Back to List</a>
+    <a asp-action="Index">Back to Account</a>
 </div>
 
 @section Scripts {

--- a/Bangazon/Views/PaymentTypes/Delete.cshtml
+++ b/Bangazon/Views/PaymentTypes/Delete.cshtml
@@ -29,12 +29,6 @@
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.AccountNumber)
         </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.User)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.User.Id)
-        </dd class>
     </dl>
     
     <form asp-action="Delete">

--- a/Bangazon/Views/PaymentTypes/Index.cshtml
+++ b/Bangazon/Views/PaymentTypes/Index.cshtml
@@ -4,17 +4,15 @@
     ViewData["Title"] = "Index";
 }
 
-<h1>Index</h1>
+    <h1>Payment Options</h1>
 
 <p>
-    <a asp-action="Create">Create New</a>
+    <a asp-action="Create">Add new payment type</a>
 </p>
 <table class="table">
     <thead>
         <tr>
-            <th>
-                @Html.DisplayNameFor(model => model.DateCreated)
-            </th>
+
             <th>
                 @Html.DisplayNameFor(model => model.Description)
             </th>
@@ -22,7 +20,7 @@
                 @Html.DisplayNameFor(model => model.AccountNumber)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.User)
+                @Html.DisplayNameFor(model => model.DateCreated)
             </th>
             <th></th>
         </tr>
@@ -30,9 +28,7 @@
     <tbody>
 @foreach (var item in Model) {
         <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.DateCreated)
-            </td>
+
             <td>
                 @Html.DisplayFor(modelItem => item.Description)
             </td>
@@ -40,7 +36,7 @@
                 @Html.DisplayFor(modelItem => item.AccountNumber)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.User.Id)
+                @Html.DisplayFor(modelItem => item.DateCreated)
             </td>
             <td>
                 <a asp-action="Edit" asp-route-id="@item.PaymentTypeId">Edit</a> |

--- a/Bangazon/Views/PaymentTypes/Index.cshtml
+++ b/Bangazon/Views/PaymentTypes/Index.cshtml
@@ -39,8 +39,6 @@
                 @Html.DisplayFor(modelItem => item.DateCreated)
             </td>
             <td>
-                <a asp-action="Edit" asp-route-id="@item.PaymentTypeId">Edit</a> |
-                <a asp-action="Details" asp-route-id="@item.PaymentTypeId">Details</a> |
                 <a asp-action="Delete" asp-route-id="@item.PaymentTypeId">Delete</a>
             </td>
         </tr>

--- a/Bangazon/Views/Products/Index.cshtml
+++ b/Bangazon/Views/Products/Index.cshtml
@@ -1,4 +1,7 @@
-﻿@* Author: Brian Jobe; View has been edited to show featured products and serve as homepage for bangzon site. *@
+﻿@* Author: Brian Jobe; View has been edited to show featured products and serve as homepage for bangzon site.
+    A search bar has been added, as well as a dropdown menu to specify search constraints. Once a search has been performed,
+    the "currentFilter" will be shown as the search string, and a conditionally rendered button will be added to go back to the
+    initial view. If a search is based on the city, the city name will be added to the product information view. *@
 
 @model IEnumerable<Bangazon.Models.Product>
 

--- a/Bangazon/Views/Products/Index.cshtml
+++ b/Bangazon/Views/Products/Index.cshtml
@@ -13,12 +13,32 @@
 <form asp-action="Index" method="get">
     <div class="form-actions no-color">
         <p>
-            Search for products by name or location: <input type="text" name="SearchString" value="@ViewData["currentFilter"]" />
-            <input type="submit" value="Search" class="btn btn-default" /> |
-            <a asp-action="Index">Back to Full List</a>
+            Search for products by name or location:
+            <div class="form-group">
+                <label for="SearchBar" class="control-label"></label>
+                <select for="SearchBar" class="form-control" name="SearchBar" value=@ViewData["SearchBar"]>
+                    <option value="0">All</option>
+                    <option value="1">City</option>
+                    <option value="2">Product Name</option>
+                </select>
+
+            </div>
+
+            <input type="text" name="SearchString" value="@ViewData["currentFilter"]" />
+            <input type="submit" value="Search" class="btn btn-default" />
+            @{ if (ViewData["currentFilter"] != null)
+                {<a asp-action="Index">Back to Full List</a>
+                }
+            }
         </p>
     </div>
 </form>
+
+@{ if (ViewData["currentFilter"] != null)
+    {
+    <h4>Search results for "@ViewData["currentFilter"]"</h4>
+    }
+}
 
 <table class="table">
     <thead>
@@ -33,23 +53,39 @@
             <th>
                 @Html.DisplayNameFor(model => model.Price)
             </th>
+
+            @{ if (ViewData["SearchBar"] != null && ViewData["SearchBar"].ToString() == "1")
+                {
+                    <th>
+                        @Html.DisplayNameFor(model => model.City)
+                    </th>
+                }
+            }
+
             <th></th>
         </tr>
     </thead>
     <tbody>
         @foreach (var item in Model)
         {
-        <tr>
-            <td>
-                <a asp-action="Details" asp-route-id="@item.ProductId">@Html.DisplayFor(modelItem => item.Title)</a> 
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Description)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Price)
-            </td>
-        </tr>
+            <tr>
+                <td>
+                    <a asp-action="Details" asp-route-id="@item.ProductId">@Html.DisplayFor(modelItem => item.Title)</a>
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Description)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Price)
+                </td>
+                @{ if (ViewData["SearchBar"] != null && ViewData["SearchBar"].ToString() == "1")
+                    {
+                        <th>
+                            @Html.DisplayFor(modelItem => item.City)
+                        </th>
+                    }
+                }
+            </tr>
         }
     </tbody>
 </table>


### PR DESCRIPTION
# Description

This PR adds a payment options view, with the ability to add a new payment type, and delete current payment types. 


Fixes Issue #14 #6 #10 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions

1. On the home page, search for items using the drop down filter to search by either city or product. If using city, the city of the product should be displayed. The search string used should also be added. 

1. Make sure you are logged in, then Click into account settings. then click payment options. You should see only the payment options for the current user. You can then add a new payment type, and delete a payment type. 



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
