### PR TITLE
Add to cart and product quantity logic update, add product inventory and update inventory.

### DIFF
--- a/Bangazon/Controllers/OrdersController.cs
+++ b/Bangazon/Controllers/OrdersController.cs
@@ -64,9 +64,6 @@ namespace Bangazon.Controllers
                 Order = order
             };
 
-
-            OrderLineItem LineItem = new OrderLineItem();
-
             viewmodel.LineItems = order.OrderProducts
                  .GroupBy(op => op.Product)
                  .Select(p => new OrderLineItem

--- a/Bangazon/Data/ApplicationDbContext.cs
+++ b/Bangazon/Data/ApplicationDbContext.cs
@@ -74,13 +74,16 @@ namespace Bangazon.Data {
                 .WithOne (l => l.Product)
                 .OnDelete (DeleteBehavior.Restrict);
 
+            
             modelBuilder.Entity<PaymentType> ()
                 .Property (b => b.DateCreated)
                 .HasDefaultValueSql ("GETDATE()");
 
+            //adds a new column to the database that allows for soft delete of payment types. 
             modelBuilder.Entity<PaymentType>()
              .Property<bool>("IsDeleted");
 
+            //adds an initial filter for all requests that removes the deleted payments from the query. 
             modelBuilder.Entity<PaymentType>()
             .HasQueryFilter(post => EF.Property<bool>(post, "IsDeleted") == false);
 

--- a/Bangazon/Models/Order.cs
+++ b/Bangazon/Models/Order.cs
@@ -14,10 +14,12 @@ namespace Bangazon.Models
     [Required]
     [DataType(DataType.Date)]
     [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
-    public DateTime DateCreated {get;set;}
+        [Display(Name = "Date Created")]
+        public DateTime DateCreated {get;set;}
 
     [DataType(DataType.Date)]
-    public DateTime? DateCompleted {get;set;}
+        [Display(Name = "Date Completed")]
+        public DateTime? DateCompleted {get;set;}
 
     [Required]
     public string UserId {get; set;}

--- a/Bangazon/Models/ProductViewModels/ProductDetailViewModel.cs
+++ b/Bangazon/Models/ProductViewModels/ProductDetailViewModel.cs
@@ -6,5 +6,7 @@ namespace Bangazon.Models.ProductViewModels
   public class ProductDetailViewModel
   {
     public Product Product { get; set; }
-  }
+
+        public int UnitsSold { get; set; }
+    }
 }

--- a/Bangazon/Models/ProductViewModels/ProductListViewModel.cs
+++ b/Bangazon/Models/ProductViewModels/ProductListViewModel.cs
@@ -6,6 +6,9 @@ namespace Bangazon.Models.ProductViewModels
 {
   public class ProductListViewModel
   {
-    public IEnumerable<Product> Products { get; set; }
+        public List<ProductDetailViewModel> ProductsWithSales { get; set; }
+
+        public readonly Product Product;
+
   }
 }

--- a/Bangazon/ViewComponents/ProductCountViewComponent.cs
+++ b/Bangazon/ViewComponents/ProductCountViewComponent.cs
@@ -58,6 +58,11 @@ namespace Bangazon.ViewComponents
             var cartList = await _context.OrderProduct.Where(op => op.OrderId == openOrder.OrderId && op.ProductId == product.ProductId).ToListAsync();
             int productCount = product.Quantity - cartList.Count();
 
+            if (productCount < 0)
+            {
+                productCount = 0;
+            }
+
             return productCount;
         }
     }

--- a/Bangazon/ViewComponents/ProductCountViewComponent.cs
+++ b/Bangazon/ViewComponents/ProductCountViewComponent.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Bangazon.Models;
+using Microsoft.AspNetCore.Identity;
+using Bangazon.Data;
+
+namespace Bangazon.ViewComponents
+{
+    public class ProductCountViewModel
+    {
+        public int ProductCount { get; set; }
+    }
+
+
+    public class ProductCountViewComponent : ViewComponent
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        private readonly ApplicationDbContext _context;
+
+        public ProductCountViewComponent(ApplicationDbContext context,
+                                UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+            _context = context;
+        }
+
+        // This method will be called every time we need to get the current user
+        private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
+
+        public async Task<IViewComponentResult> InvokeAsync(int productId)
+        {
+            var quantityRemaining = await GetItemsAsync(productId);
+            ProductCountViewModel model = new ProductCountViewModel
+            {
+                ProductCount = quantityRemaining
+            };
+
+
+            return View(model);
+        }
+        private async Task<int> GetItemsAsync(int productId)
+        {
+            var user = await GetCurrentUserAsync();
+
+            // See if the user has an open order
+            var openOrder = await _context.Order.SingleOrDefaultAsync(o => o.User == user && o.PaymentTypeId == null);
+
+            var product = await _context.Product.Where(p => p.ProductId == productId).SingleOrDefaultAsync();
+
+           if (openOrder == null)
+            {
+                return product.Quantity;
+            }
+            var cartList = await _context.OrderProduct.Where(op => op.OrderId == openOrder.OrderId && op.ProductId == product.ProductId).ToListAsync();
+            int productCount = product.Quantity - cartList.Count();
+
+            return productCount;
+        }
+    }
+}

--- a/Bangazon/ViewComponents/ProductCountViewComponent.cs
+++ b/Bangazon/ViewComponents/ProductCountViewComponent.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿// Author: Brian Jobe This view component updates the product quantity for individual users when adding products to the cart. 
+// It allows the correct remaining quantity to be displayed without updating the quantity in the database.  
+
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;

--- a/Bangazon/Views/Orders/CheckoutError.cshtml
+++ b/Bangazon/Views/Orders/CheckoutError.cshtml
@@ -1,0 +1,9 @@
+﻿@model Bangazon.Models.OrderViewModels.OrderLineItem
+@{
+    ViewData["Title"] = "CheckoutError";
+}
+
+<h1>Checkout Error</h1>
+
+<p>There are only @Html.DisplayFor(model => model.Product.Quantity) remaining units of @Html.DisplayFor(model => model.Product.Title) for sale.</p>
+<p>Please remove @ViewBag.UnitsOver units from your cart to continue checking out. </p>

--- a/Bangazon/Views/Orders/CheckoutError.cshtml
+++ b/Bangazon/Views/Orders/CheckoutError.cshtml
@@ -7,3 +7,7 @@
 
 <p>There are only @Html.DisplayFor(model => model.Product.Quantity) remaining units of @Html.DisplayFor(model => model.Product.Title) for sale.</p>
 <p>Please remove @ViewBag.UnitsOver units from your cart to continue checking out. </p>
+
+<div>
+    <a href='javascript:history.go(-1)'>Go Back</a>
+</div>

--- a/Bangazon/Views/Orders/Edit.cshtml
+++ b/Bangazon/Views/Orders/Edit.cshtml
@@ -6,6 +6,41 @@
 
 <h1>Checkout</h1>
 
+<div>
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                Product
+            </th>
+            <th>
+                Price
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var item in Model.OrderProducts)
+        {
+        <tr>
+
+            <td>
+                @Html.DisplayFor(modelItem => item.Product.Title)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Product.Price)
+            </td>
+
+        </tr>
+        }
+    </tbody>
+</table>
+</div>
+
+
+
+
+
 <h4>Select a payment method to complete order.</h4>
 <hr />
 <div class="row">

--- a/Bangazon/Views/Orders/OrderHistoryDetail.cshtml
+++ b/Bangazon/Views/Orders/OrderHistoryDetail.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "OrderHistoryDetail";
 }
 
-<h1>OrderHistoryDetail</h1>
+<h1>Order Detail</h1>
 
 <div>
     <h4>Order</h4>

--- a/Bangazon/Views/Products/Details.cshtml
+++ b/Bangazon/Views/Products/Details.cshtml
@@ -42,7 +42,8 @@
     @{ var currentUser = SignInManager.UserManager.GetUserId(User);
 
         if (currentUser != null && Model.UserId == currentUser)
-        { <p>This is your product listing.</p>
+        { <p>This is your product listing.</p>  
+          <a asp-action="Edit" asp-route-id="@Model.ProductId">Update Inventory</a>
         }
         else if (ViewBag.ProductCount > 0)
         {

--- a/Bangazon/Views/Products/Details.cshtml
+++ b/Bangazon/Views/Products/Details.cshtml
@@ -30,7 +30,7 @@
             @Html.DisplayNameFor(model => model.Quantity)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Quantity)
+            @await Component.InvokeAsync("ProductCount", new { productId = Model.ProductId })
         </dd>
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Price)
@@ -44,7 +44,7 @@
         if (currentUser != null && Model.UserId == currentUser)
         { <p>This is your product listing.</p>
         }
-        else if (Model.Quantity > 0)
+        else if (ViewBag.ProductCount > 0)
         {
             <a asp-controller="Orders" asp-action="AddToCart" asp-route-id="@Model.ProductId">Add to Cart</a>
         }

--- a/Bangazon/Views/Products/Edit.cshtml
+++ b/Bangazon/Views/Products/Edit.cshtml
@@ -4,9 +4,9 @@
     ViewData["Title"] = "Edit";
 }
 
-<h1>Edit</h1>
+<h1>Update Item Inventory</h1>
 
-<h4>Product</h4>
+<h4>@Html.DisplayFor(model => model.Title)</h4>
 <hr />
 <div class="row">
     <div class="col-md-4">
@@ -14,49 +14,9 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="ProductId" />
             <div class="form-group">
-                <label asp-for="Description" class="control-label"></label>
-                <input asp-for="Description" class="form-control" />
-                <span asp-validation-for="Description" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Title" class="control-label"></label>
-                <input asp-for="Title" class="form-control" />
-                <span asp-validation-for="Title" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Price" class="control-label"></label>
-                <input asp-for="Price" class="form-control" />
-                <span asp-validation-for="Price" class="text-danger"></span>
-            </div>
-            <div class="form-group">
                 <label asp-for="Quantity" class="control-label"></label>
                 <input asp-for="Quantity" class="form-control" />
                 <span asp-validation-for="Quantity" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="UserId" class="control-label"></label>
-                <select asp-for="UserId" class="form-control" asp-items="ViewBag.UserId"></select>
-                <span asp-validation-for="UserId" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="City" class="control-label"></label>
-                <input asp-for="City" class="form-control" />
-                <span asp-validation-for="City" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="ImagePath" class="control-label"></label>
-                <input asp-for="ImagePath" class="form-control" />
-                <span asp-validation-for="ImagePath" class="text-danger"></span>
-            </div>
-            <div class="form-group form-check">
-                <label class="form-check-label">
-                    <input class="form-check-input" asp-for="Active" /> @Html.DisplayNameFor(model => model.Active)
-                </label>
-            </div>
-            <div class="form-group">
-                <label asp-for="ProductTypeId" class="control-label"></label>
-                <select asp-for="ProductTypeId" class="form-control" asp-items="ViewBag.ProductTypeId"></select>
-                <span asp-validation-for="ProductTypeId" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <input type="submit" value="Save" class="btn btn-primary" />
@@ -66,7 +26,7 @@
 </div>
 
 <div>
-    <a asp-action="Index">Back to List</a>
+    <a asp-action="MyProducts">Back to My Products</a>
 </div>
 
 @section Scripts {

--- a/Bangazon/Views/Products/MyProducts.cshtml
+++ b/Bangazon/Views/Products/MyProducts.cshtml
@@ -67,8 +67,8 @@
                 @Html.DisplayFor(modelItem => item.Product.ProductType.Label)
             </td>
             <td>
-                <a asp-action="Details" asp-route-id="@item.Product.ProductId">Details</a> |
-                <a asp-action="Delete" asp-route-id="@item.Product.ProductId">Delete</a>
+                <a asp-action="Details" asp-route-id="@item.Product.ProductId">Details</a>
+                @*<a asp-action="Delete" asp-route-id="@item.Product.ProductId">Delete</a>*@
             </td>
         </tr>
 }

--- a/Bangazon/Views/Products/MyProducts.cshtml
+++ b/Bangazon/Views/Products/MyProducts.cshtml
@@ -1,4 +1,4 @@
-﻿@model IEnumerable<Bangazon.Models.Product>
+﻿@model Bangazon.Models.ProductViewModels.ProductListViewModel
 
 @{
     ViewData["Title"] = "MyProducts";
@@ -13,64 +13,62 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.DateCreated)
-            </th>
-
-            <th>
-                @Html.DisplayNameFor(model => model.Title)
+                @Html.DisplayNameFor(model => model.Product.Title)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Description)
+                @Html.DisplayNameFor(model => model.Product.Description)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Price)
+                @Html.DisplayNameFor(model => model.Product.Price)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Quantity)
+                Inventory
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.City)
+                Units Sold
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Active)
+                @Html.DisplayNameFor(model => model.Product.City)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.ProductType)
+                @Html.DisplayNameFor(model => model.Product.Active)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Product.ProductType)
             </th>
             <th></th>
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model) {
+@foreach (var item in Model.ProductsWithSales) {
         <tr>
             <td>
-                @Html.DisplayFor(modelItem => item.DateCreated)
-            </td>
-
-            <td>
-                @Html.DisplayFor(modelItem => item.Title)
+                @Html.DisplayFor(modelItem => item.Product.Title)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Description)
+                @Html.DisplayFor(modelItem => item.Product.Description)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Price)
+                @Html.DisplayFor(modelItem => item.Product.Price)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Quantity)
+                @Html.DisplayFor(modelItem => item.Product.Quantity)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.City)
+                @Html.DisplayFor(modelItem => item.UnitsSold)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Active)
+                @Html.DisplayFor(modelItem => item.Product.City)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.ProductType.Label)
+                @Html.DisplayFor(modelItem => item.Product.Active)
             </td>
             <td>
-                <a asp-action="Details" asp-route-id="@item.ProductId">Details</a> |
-                <a asp-action="Delete" asp-route-id="@item.ProductId">Delete</a>
+                @Html.DisplayFor(modelItem => item.Product.ProductType.Label)
+            </td>
+            <td>
+                <a asp-action="Details" asp-route-id="@item.Product.ProductId">Details</a> |
+                <a asp-action="Delete" asp-route-id="@item.Product.ProductId">Delete</a>
             </td>
         </tr>
 }

--- a/Bangazon/Views/Shared/Components/ProductCount/Default.cshtml
+++ b/Bangazon/Views/Shared/Components/ProductCount/Default.cshtml
@@ -1,0 +1,3 @@
+﻿@model Bangazon.ViewComponents.ProductCountViewModel
+
+<span >(@Model.ProductCount)</span>

--- a/Bangazon/Views/Shared/Components/ProductCount/Default.cshtml
+++ b/Bangazon/Views/Shared/Components/ProductCount/Default.cshtml
@@ -1,3 +1,3 @@
 ﻿@model Bangazon.ViewComponents.ProductCountViewModel
 
-<span >(@Model.ProductCount)</span>
+<span >@Model.ProductCount</span>


### PR DESCRIPTION
# Description

Changed add to cart and  complete purchase logic so that product quantity is not updated until the order is completed. Other users can purchase items that are in another user's cart. If the product becomes sold out while sitting in a user's cart, an error will be shown and the user can remove it from their cart. 

When viewing my products page, inventory remaining and total sold should be shown. When the product seller hits the details page of their products, they can hit update and update the quantity in stock.


#50 



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Testing Instructions

1. git fetch and checkout update-product-details
1. add all of 1 product to cart, logout, login different user, add the same product and checkout, then login other user to checkout. Error should be thrown.  
1. go to my products, check out inventory, then view details of a product and update the quantity. 


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added test instructions that prove my fix is effective or that my feature works
